### PR TITLE
BUGFIX: Fix LoadJSON panicking

### DIFF
--- a/internal/retrievers/mapping/mapping_test.go
+++ b/internal/retrievers/mapping/mapping_test.go
@@ -1,6 +1,7 @@
 package mapping_test
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -12,30 +13,31 @@ import (
 
 type MappingSuite struct {
     suite.Suite
-    dir            string
-    extensionsFile string
-    componentsFile string
+    extensions     string
+    components     string
+    broken         string
 }
 
-
 func (s *MappingSuite) SetupSuite() {
-    s.dir = "testdata"
-    s.extensionsFile = filepath.Join("..", "..", "..", "assets", "extensions.json")
-    s.componentsFile = filepath.Join("..", "..", "..", "assets", "components.json")
+    rawExtensions, _ := os.ReadFile(filepath.Join("..", "..", "..", "assets", "extensions.json"))
+    s.extensions = string(rawExtensions)
+    rawComponents, _ := os.ReadFile(filepath.Join("..", "..", "..", "assets", "components.json"))
+    s.components = string(rawComponents)
+    rawBroken, _ := os.ReadFile(filepath.Join("..", "..", "..", "testdata", "broken.json.txt"))
+    s.broken = string(rawBroken)
 }
 
 func (s *MappingSuite) TestLoadJSON() {
-    response := mapping.LoadJSON[map[string]string](s.extensionsFile)
+    response := mapping.LoadJSON[map[string]string](s.extensions)
 
     assert.IsType(s.T(), map[string]string{}, response)
-
-    assert.Panics(s.T(), func() {mapping.LoadJSON[map[string]string](filepath.Join(s.dir, "broken.json.txt"))})
+    assert.Panics(s.T(), func() {mapping.LoadJSON[map[string]string](s.broken)})
 }
 
 func (s *MappingSuite) TestLoadMapping() {
     mapping.Load(
-        s.componentsFile,
-        s.extensionsFile,
+        s.components,
+        s.extensions,
     )
 
     assert.NotNil(s.T(), mapping.Components)

--- a/internal/retrievers/mapping/retriever.go
+++ b/internal/retrievers/mapping/retriever.go
@@ -3,7 +3,6 @@ package mapping
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 )
 
 var (
@@ -11,23 +10,17 @@ var (
     Components ComponentsMapping
 )
 
-func LoadJSON[mapType any](fileName string) mapType {
-    content, err := os.ReadFile(fileName)
-    if err != nil {
-        panic(InvalidJSON{Message: fmt.Sprintf("Error opening JSON at %s", fileName)})
-    }
-
+func LoadJSON[mapType any](content string) mapType {
     var mapping mapType
-    err = json.Unmarshal([]byte(string(content)), &mapping)
+    err := json.Unmarshal([]byte(string(content)), &mapping)
     if err != nil {
-        panic(&InvalidJSON{Message: fmt.Sprintf("Error parsing JSON mapping at %s", fileName)})
+        panic(&InvalidJSON{Message: fmt.Sprintf("Error parsing JSON mapping %s", content)})
     }
-
     return mapping
 }
 
-func Load(componentsPath string, extensionsPath string) (ComponentsMapping, ExtensionsMapping) {
-    Components = LoadJSON[ComponentsMapping](componentsPath)
-    Extensions = LoadJSON[ExtensionsMapping](extensionsPath)
+func Load(rawComponents string, rawExtensions string) (ComponentsMapping, ExtensionsMapping) {
+    Components = LoadJSON[ComponentsMapping](rawComponents)
+    Extensions = LoadJSON[ExtensionsMapping](rawExtensions)
     return Components, Extensions
 }

--- a/main.go
+++ b/main.go
@@ -8,10 +8,7 @@ import (
 )
 
 func GetStatistics(path string) (*StatisticsResponse, error) {
-    mapping.Load(
-        "assets/components.json",
-        "assets/extensions.json",
-    )
+    mapping.Load(rawComponents, rawExtensions)
 
     list, err := tree.List(path)
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package statloc_test
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -12,17 +13,16 @@ import (
 
 type ServiceSuite struct {
     suite.Suite
-    dir     string
     results map[string]map[string]uint64
 }
 
 func (s *ServiceSuite) SetupSuite() {
-    s.dir = "testdata"
-    s.results = mapping.LoadJSON[map[string]map[string]uint64](filepath.Join(s.dir, "results.json"))
+    rawResults, _ := os.ReadFile(filepath.Join("testdata", "results.json"))
+    s.results = mapping.LoadJSON[map[string]map[string]uint64](string(rawResults))
 }
 
 func (s *ServiceSuite) TestGetStatistics() {
-    response, err := core.GetStatistics(s.dir)
+    response, err := core.GetStatistics("testdata")
 
     assert.Nil(s.T(), err)
 

--- a/utils.go
+++ b/utils.go
@@ -1,10 +1,19 @@
 package statloc
 
 import (
+	_ "embed"
 	"path/filepath"
 
 	"github.com/statloc/core/internal/retrievers/mapping"
 	"github.com/statloc/core/internal/retrievers/tree"
+)
+
+var (
+    //go:embed "assets/extensions.json"
+    rawExtensions string
+
+    //go:embed "assets/components.json"
+    rawComponents string
 )
 
 func goAroundCalculating(


### PR DESCRIPTION
### ✏️ Short description
Fix `LoadJSON` panicking reading JSON assets by using `//go:embed` instead of `os.ReadDir`

### 📜 Changes
1. use `go:embed` instead of `os.ReadDir`
2. pass file content as a raw string to `LoadJSON`
