### PR TITLE
ENHANCEMENT: cover package `tree` with tests

### DIFF
--- a/internal/tree/tree_test.go
+++ b/internal/tree/tree_test.go
@@ -1,6 +1,7 @@
 package tree_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -34,6 +35,12 @@ func (s *TreeSuite) SetupSuite() {
 	s.tree = t.Tree{WorkDir: workdir}
 }
 
+func (s *TreeSuite) TestCopy() {
+    response := s.tree.Copy()
+
+    assert.Equal(s.T(), t.Tree{WorkDir: s.tree.WorkDir}, response)
+}
+
 func (s *TreeSuite) TestList() {
     response, err := s.tree.List(s.dir)
     assert.Nil(s.T(), err)
@@ -46,12 +53,26 @@ func (s *TreeSuite) TestList() {
 
 func (s *TreeSuite) TestChdir() {
     err := s.tree.Chdir("non_existing_dir")
+    wd := s.tree.WorkDir
+
     assert.NotNil(s.T(), err)
+    assert.EqualError(s.T(), err, "\"non_existing_dir\": no such file or directory")
+    assert.Equal(s.T(), wd, s.tree.WorkDir)
+
+    err = s.tree.Chdir(filepath.Join("..", "..", "testdata", "results.json"))
+    assert.NotNil(s.T(), err)
+    assert.EqualError(
+        s.T(),
+        err,
+        fmt.Sprintf("\"%s\" is not a directory", filepath.Join("..", "..", "testdata", "results.json")),
+    )
 
     err = s.tree.Chdir(filepath.Join("..", "..", "testdata"))
     assert.Nil(s.T(), err)
+    assert.Equal(s.T(), filepath.Join(wd, "..", "..", "testdata"), s.tree.WorkDir)
 
     err = s.tree.Chdir(filepath.Join("..", "internal", "tree"))
+    assert.Equal(s.T(), wd, s.tree.WorkDir)
     assert.Nil(s.T(), err)
 }
 


### PR DESCRIPTION
### ✏️ Short description
Cover package `tree` with tests (#37)
